### PR TITLE
Moved the version statement to the first line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-# Set the name and the supported language of the project
-project(hello-world C)
 # Set the minimum version of cmake required to build this project
 cmake_minimum_required(VERSION 2.6)
+# Set the name and the supported language of the project
+project(hello-world C)
 # Use the package PkgConfig to detect GTK+ headers/library files
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTK3 REQUIRED gtk+-3.0)


### PR DESCRIPTION
Current implementation throws a warning:
```
CMake Warning (dev) at CMakeLists.txt:3 (project):
cmake_minimum_required() should be called prior to this top-level project() call.
```

This commit fixes this problem by moving line to the top of the file.